### PR TITLE
Add quiet option, fix field width issue, addPy 3 compatibility

### DIFF
--- a/gtfsrdb.py
+++ b/gtfsrdb.py
@@ -27,7 +27,10 @@ import time
 import sys
 from optparse import OptionParser
 import logging
-from urllib2 import urlopen
+try:
+    from urllib2 import urlopen
+except ImportError:
+    from urllib.request import urlopen
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 import gtfs_realtime_pb2

--- a/gtfsrdb.py
+++ b/gtfsrdb.py
@@ -22,32 +22,32 @@
 # Matt Conway: main code
 # Jorge Adorno
 
-from optparse import OptionParser
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from urllib2 import urlopen
-from model import *
-import gtfs_realtime_pb2
 import datetime
 import time
 import sys
+from optparse import OptionParser
+from urllib2 import urlopen
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import gtfs_realtime_pb2
+from model import *
 
 p = OptionParser()
 
-p.add_option('-t', '--trip-updates', dest='tripUpdates', default=None, 
+p.add_option('-t', '--trip-updates', dest='tripUpdates', default=None,
              help='The trip updates URL', metavar='URL')
 
-p.add_option('-a', '--alerts', default=None, dest='alerts', 
+p.add_option('-a', '--alerts', default=None, dest='alerts',
              help='The alerts URL', metavar='URL')
 
-p.add_option('-p', '--vehicle-positions', dest='vehiclePositions', default=None, 
+p.add_option('-p', '--vehicle-positions', dest='vehiclePositions', default=None,
              help='The vehicle positions URL', metavar='URL')
 
 p.add_option('-d', '--database', default=None, dest='dsn',
              help='Database connection string', metavar='DSN')
 
-p.add_option('-o', '--discard-old', default=False, dest='deleteOld', 
-             action='store_true', 
+p.add_option('-o', '--discard-old', default=False, dest='deleteOld',
+             action='store_true',
              help='Dicard old updates, so the database is always current')
 
 p.add_option('-c', '--create-tables', default=False, dest='create',
@@ -56,7 +56,7 @@ p.add_option('-c', '--create-tables', default=False, dest='create',
 p.add_option('-w', '--wait', default=30, type='int', metavar='SECS',
              dest='timeout', help='Time to wait between requests (in seconds)')
 
-p.add_option('-v', '--verbose', default=False, dest='verbose', 
+p.add_option('-v', '--verbose', default=False, dest='verbose',
              action='store_true', help='Print generated SQL')
 
 p.add_option('-l', '--language', default='en', dest='lang', metavar='LANG',
@@ -67,23 +67,23 @@ p.add_option('-1', '--once',  default=False, dest='once', action='store_true',
 
 opts, args = p.parse_args()
 
-if opts.dsn == None:
+if opts.dsn is None:
     print 'No database specified!'
     exit(1)
 
-if opts.alerts == None and opts.tripUpdates == None and opts.vehiclePositions == None:
+if opts.alerts is None and opts.tripUpdates is None and opts.vehiclePositions is None:
     print 'No trip updates, alerts, or vehicle positions URLs were specified!'
     exit(1)
 
-if opts.alerts == None:
+if opts.alerts is None:
     print 'Warning: no alert URL specified, proceeding without alerts'
 
-if opts.tripUpdates == None:
+if opts.tripUpdates is None:
     print 'Warning: no trip update URL specified, proceeding without trip updates'
 
-if opts.vehiclePositions == None:
+if opts.vehiclePositions is None:
     print 'Warning: no vehicle positions URL specified, proceeding without vehicle positions'
-    
+
 # Connect to the database
 engine = create_engine(opts.dsn, echo=opts.verbose)
 # sessionmaker returns a class
@@ -100,8 +100,8 @@ for table in Base.metadata.tables.keys():
             print 'Missing table %s! Use -c to create it.' % table
             exit(1)
 
-# Get a specific translation from a TranslatedString
 def getTrans(string, lang):
+    '''Get a specific translation from a TranslatedString.'''
     # If we don't find the requested language, return this
     untranslated = None
 
@@ -112,7 +112,7 @@ def getTrans(string, lang):
     for t in string.translation:
         if t.language == lang:
             return t.text
-        if t.language == None:
+        if t.language is None:
             untranslated = t.text
     return untranslated
 
@@ -120,7 +120,7 @@ try:
     keep_running = True
     while keep_running:
         try:
-        #if True:
+            # if True:
             if opts.deleteOld:
                 # Go through all of the tables that we create, clear them
                 # Don't mess with other tables (i.e., tables from static GTFS)
@@ -132,7 +132,7 @@ try:
                 fm = gtfs_realtime_pb2.FeedMessage()
                 fm.ParseFromString(
                     urlopen(opts.tripUpdates).read()
-                    )
+                )
 
                 # Convert this a Python object, and save it to be placed into each
                 # trip_update
@@ -148,34 +148,37 @@ try:
                     tu = entity.trip_update
 
                     dbtu = TripUpdate(
-                        trip_id = tu.trip.trip_id,
-                        route_id = tu.trip.route_id,
-                        trip_start_time = tu.trip.start_time,
-                        trip_start_date = tu.trip.start_date,
+                        trip_id=tu.trip.trip_id,
+                        route_id=tu.trip.route_id,
+                        trip_start_time=tu.trip.start_time,
+                        trip_start_date=tu.trip.start_date,
 
                         # get the schedule relationship
-                        # This is somewhat undocumented, but by referencing the 
+                        # This is somewhat undocumented, but by referencing the
                         # DESCRIPTOR.enum_types_by_name, you get a dict of enum types
-                        # as described at http://code.google.com/apis/protocolbuffers/docs/reference/python/google.protobuf.descriptor.EnumDescriptor-class.html
-                        schedule_relationship = tu.trip.DESCRIPTOR.enum_types_by_name['ScheduleRelationship'].values_by_number[tu.trip.schedule_relationship].name,
+                        # as described at
+                        # http://code.google.com/apis/protocolbuffers/docs/reference/python/google.protobuf.descriptor.EnumDescriptor-class.html
+                        schedule_relationship=tu.trip.DESCRIPTOR.enum_types_by_name[
+                            'ScheduleRelationship'].values_by_number[tu.trip.schedule_relationship].name,
 
-                        vehicle_id = tu.vehicle.id,
-                        vehicle_label = tu.vehicle.label,
-                        vehicle_license_plate = tu.vehicle.license_plate,
-                        timestamp = timestamp)
+                        vehicle_id=tu.vehicle.id,
+                        vehicle_label=tu.vehicle.label,
+                        vehicle_license_plate=tu.vehicle.license_plate,
+                        timestamp=timestamp)
 
                     for stu in tu.stop_time_update:
                         dbstu = StopTimeUpdate(
-                            stop_sequence = stu.stop_sequence,
-                            stop_id = stu.stop_id,
-                            arrival_delay = stu.arrival.delay,
-                            arrival_time = stu.arrival.time,
-                            arrival_uncertainty = stu.arrival.uncertainty,
-                            departure_delay = stu.departure.delay,
-                            departure_time = stu.departure.time,
-                            departure_uncertainty = stu.departure.uncertainty,
-                            schedule_relationship = tu.trip.DESCRIPTOR.enum_types_by_name['ScheduleRelationship'].values_by_number[tu.trip.schedule_relationship].name
-                            )
+                            stop_sequence=stu.stop_sequence,
+                            stop_id=stu.stop_id,
+                            arrival_delay=stu.arrival.delay,
+                            arrival_time=stu.arrival.time,
+                            arrival_uncertainty=stu.arrival.uncertainty,
+                            departure_delay=stu.departure.delay,
+                            departure_time=stu.departure.time,
+                            departure_uncertainty=stu.departure.uncertainty,
+                            schedule_relationship=tu.trip.DESCRIPTOR.enum_types_by_name[
+                                'ScheduleRelationship'].values_by_number[tu.trip.schedule_relationship].name
+                        )
                         session.add(dbstu)
                         dbtu.StopTimeUpdates.append(dbstu)
 
@@ -185,7 +188,7 @@ try:
                 fm = gtfs_realtime_pb2.FeedMessage()
                 fm.ParseFromString(
                     urlopen(opts.alerts).read()
-                    )
+                )
 
                 # Convert this a Python object, and save it to be placed into each
                 # trip_update
@@ -199,35 +202,35 @@ try:
                     for entity in fm.entity:
                         alert = entity.alert
                         dbalert = Alert(
-                            start = alert.active_period[0].start,
-                            end = alert.active_period[0].end,
-                            cause = alert.DESCRIPTOR.enum_types_by_name['Cause'].values_by_number[alert.cause].name,
-                            effect = alert.DESCRIPTOR.enum_types_by_name['Effect'].values_by_number[alert.effect].name,
-                            url = getTrans(alert.url, opts.lang),
-                            header_text = getTrans(alert.header_text, opts.lang),
-                            description_text = getTrans(alert.description_text,
-                                                        opts.lang)
-                            )
+                            start=alert.active_period[0].start,
+                            end=alert.active_period[0].end,
+                            cause=alert.DESCRIPTOR.enum_types_by_name['Cause'].values_by_number[alert.cause].name,
+                            effect=alert.DESCRIPTOR.enum_types_by_name['Effect'].values_by_number[alert.effect].name,
+                            url=getTrans(alert.url, opts.lang),
+                            header_text=getTrans(alert.header_text, opts.lang),
+                            description_text=getTrans(alert.description_text,
+                                                      opts.lang)
+                        )
 
                         session.add(dbalert)
                         for ie in alert.informed_entity:
                             dbie = EntitySelector(
-                                agency_id = ie.agency_id,
-                                route_id = ie.route_id,
-                                route_type = ie.route_type,
-                                stop_id = ie.stop_id,
+                                agency_id=ie.agency_id,
+                                route_id=ie.route_id,
+                                route_type=ie.route_type,
+                                stop_id=ie.stop_id,
 
-                                trip_id = ie.trip.trip_id,
-                                trip_route_id = ie.trip.route_id,
-                                trip_start_time = ie.trip.start_time,
-                                trip_start_date = ie.trip.start_date)
+                                trip_id=ie.trip.trip_id,
+                                trip_route_id=ie.trip.route_id,
+                                trip_start_time=ie.trip.start_time,
+                                trip_start_date=ie.trip.start_date)
                             session.add(dbie)
                             dbalert.InformedEntities.append(dbie)
             if opts.vehiclePositions:
                 fm = gtfs_realtime_pb2.FeedMessage()
                 fm.ParseFromString(
                     urlopen(opts.vehiclePositions).read()
-                    )
+                )
 
                 # Convert this a Python object, and save it to be placed into each
                 # vehicle_position
@@ -243,34 +246,34 @@ try:
                     vp = entity.vehicle
 
                     dbvp = VehiclePosition(
-                        trip_id = vp.trip.trip_id,
-                        route_id = vp.trip.route_id,
-                        trip_start_time = vp.trip.start_time,
-                        trip_start_date = vp.trip.start_date,                      
-                        vehicle_id = vp.vehicle.id,
-                        vehicle_label = vp.vehicle.label,
-                        vehicle_license_plate = vp.vehicle.license_plate,
-                        position_latitude = vp.position.latitude,
-                        position_longitude = vp.position.longitude,
-                        position_bearing = vp.position.bearing,
-                        position_speed = vp.position.speed,
-                        occupancy_status = gtfs_realtime_pb2.VehicleDescriptor.OccupancyStatus.DESCRIPTOR.values_by_number[vp.occupancy_status].name,
-                        timestamp = timestamp)
-                    
+                        trip_id=vp.trip.trip_id,
+                        route_id=vp.trip.route_id,
+                        trip_start_time=vp.trip.start_time,
+                        trip_start_date=vp.trip.start_date,
+                        vehicle_id=vp.vehicle.id,
+                        vehicle_label=vp.vehicle.label,
+                        vehicle_license_plate=vp.vehicle.license_plate,
+                        position_latitude=vp.position.latitude,
+                        position_longitude=vp.position.longitude,
+                        position_bearing=vp.position.bearing,
+                        position_speed=vp.position.speed,
+                        occupancy_status=gtfs_realtime_pb2.VehicleDescriptor.OccupancyStatus.DESCRIPTOR.values_by_number[
+                            vp.occupancy_status].name,
+                        timestamp=timestamp)
+
                     session.add(dbvp)
 
             # This does deletes and adds, since it's atomic it never leaves us
             # without data
             session.commit()
         except:
-        #else:
+            # else:
             print 'Exception occurred in iteration'
             print sys.exc_info()
 
-
-        # put this outside the try...except so it won't be skipped when something 
+        # put this outside the try...except so it won't be skipped when something
         # fails
-        # also, makes it easier to end the process with ctrl-c, b/c a 
+        # also, makes it easier to end the process with ctrl-c, b/c a
         # KeyboardInterrupt here will end the program (cleanly)
         if opts.once:
             print "Executed the load ONCE ... going to stop now..."

--- a/model.py
+++ b/model.py
@@ -49,8 +49,8 @@ class TripUpdate(Base):
 
     # This replaces the TripDescriptor message
     # TODO: figure out the relations
-    trip_id = Column(String(10))
-    route_id = Column(String(10))
+    trip_id = Column(String(64))
+    route_id = Column(String(64))
     trip_start_time = Column(String(8))
     trip_start_date = Column(String(10))
     # Put in the string value not the enum
@@ -120,13 +120,13 @@ class EntitySelector(Base):
     oid = Column(Integer, primary_key=True)
 
     agency_id = Column(String(15))
-    route_id = Column(String(10))
+    route_id = Column(String(64))
     route_type = Column(Integer)
     stop_id = Column(String(10))
 
     # Collapsed TripDescriptor
-    trip_id = Column(String(10))
-    trip_route_id = Column(String(10))
+    trip_id = Column(String(64))
+    trip_route_id = Column(String(64))
     trip_start_time = Column(String(8))
     trip_start_date = Column(String(10))
 
@@ -139,8 +139,8 @@ class VehiclePosition(Base):
 
     # This replaces the TripDescriptor message
     # TODO: figure out the relations
-    trip_id = Column(String(10))
-    route_id = Column(String(10))
+    trip_id = Column(String(64))
+    route_id = Column(String(64))
     trip_start_time = Column(String(8))
     trip_start_date = Column(String(10))
 

--- a/model.py
+++ b/model.py
@@ -42,6 +42,7 @@ Base = declarative_base()
 # The oid is called oid because several of the GTFSr types have string ids
 # TODO: add sequences
 
+
 class TripUpdate(Base):
     __tablename__ = 'trip_updates'
     oid = Column(Integer, primary_key=True)
@@ -65,7 +66,8 @@ class TripUpdate(Base):
     timestamp = Column(DateTime)
 
     StopTimeUpdates = relationship('StopTimeUpdate', backref='TripUpdate')
-    
+
+
 class StopTimeUpdate(Base):
     __tablename__ = 'stop_time_updates'
     oid = Column(Integer, primary_key=True)
@@ -89,8 +91,9 @@ class StopTimeUpdate(Base):
 
     # Link it to the TripUpdate
     trip_update_id = Column(Integer, ForeignKey('trip_updates.oid'))
-    
+
     # The .TripUpdate is done by the backref in TripUpdate
+
 
 class Alert(Base):
     __tablename__ = 'alerts'
@@ -99,7 +102,7 @@ class Alert(Base):
 
     # Collapsed TimeRange
     start = Column(Integer)
-    end = Column(Integer)    
+    end = Column(Integer)
 
     # Add domain
     cause = Column(String(20))
@@ -110,6 +113,7 @@ class Alert(Base):
     description_text = Column(String(4000))
 
     InformedEntities = relationship('EntitySelector', backref='Alert')
+
 
 class EntitySelector(Base):
     __tablename__ = 'entity_selectors'
@@ -128,6 +132,7 @@ class EntitySelector(Base):
 
     alert_id = Column(Integer, ForeignKey('alerts.oid'))
 
+
 class VehiclePosition(Base):
     __tablename__ = 'vehicle_positions'
     oid = Column(Integer, primary_key=True)
@@ -138,12 +143,12 @@ class VehiclePosition(Base):
     route_id = Column(String(10))
     trip_start_time = Column(String(8))
     trip_start_date = Column(String(10))
- 
+
     # Collapsed VehicleDescriptor
     vehicle_id = Column(String(10))
     vehicle_label = Column(String(15))
     vehicle_license_plate = Column(String(10))
-    
+
     # Collapsed Position
     position_latitude = Column(Float)
     position_longitude = Column(Float)
@@ -154,7 +159,7 @@ class VehiclePosition(Base):
 
     # moved from the header, and reformatted as datetime
     timestamp = Column(DateTime)
-   
+
 
 # So one can loop over all classes to clear them for a new load (-o option)
 AllClasses = (TripUpdate, StopTimeUpdate, Alert, EntitySelector, VehiclePosition)


### PR DESCRIPTION
These commits:
* Run an automatic PEP8 formatter
* Use wider fields for `route_id` and `trip_id` (Many systems use more than 10 characters for these values
* Adds a quiet option, managed by `logging`
* Adds python3 compatibility for the heck of it, since it's only a two-line change after the above