### PR TITLE
adjusted killAfter condition to not require stop_time be declared

### DIFF
--- a/gtfsrdb.py
+++ b/gtfsrdb.py
@@ -147,8 +147,9 @@ if opts.killAfter > 0:
 try:
     keep_running = True
     while keep_running:
-        if datetime.datetime.now() > stop_time:
-            sys.exit()
+        if opts.killAfter > 0:
+            if datetime.datetime.now() > stop_time:
+                sys.exit()
         try:
             # if True:
             if opts.deleteOld:


### PR DESCRIPTION
past version did not run without the killAfter flag provided